### PR TITLE
Redirect Resume Link to github-tracked version

### DIFF
--- a/index.html
+++ b/index.html
@@ -243,8 +243,8 @@
 			<div>
 				<a href="#contact" title="Hire Me" class="button stroke smoothscroll">Hire Me</a>
 				<!-- pdfs/sebvc_Resume.pdf is from Oct2021 -->
-				<a href="pdfs/sebvc_Resume.pdf" 
-				target="_blank" rel="noopener" title="Download Resume (Sept 2022)" class="button button-primary">Download Resume</a>
+				<a href="https://nbviewer.org/github/sebvc/Resume/blob/main/sebvc_Resume.pdf" 
+				target="_blank" rel="noopener" title="Download Most Recent Resume" class="button button-primary">Download Resume</a>
 				<!-- pdfs/sebvc_Unofficial_Transcript.pdf is from Sept. 2022 -->
 				<a href="pdfs/sebvc_Unofficial_Transcript.pdf"
 					target="_blank" rel="noopener" title="View Transcript (Sept 2022)" class="button button-secondary">View Transcript</a>


### PR DESCRIPTION
For live pdf preview using
- https://nbviewer.org/
- https://nbviewer.org/github/sebvc/Resume/blob/main/sebvc_Resume.pdf

Since GitHub deprecates hyperlinks:
- https://github.com/sebvc/Resume/blob/main/sebvc_Resume.pdf